### PR TITLE
encryption at rest basic APIs

### DIFF
--- a/buckets/manage_bucket.py
+++ b/buckets/manage_bucket.py
@@ -16,6 +16,26 @@ class BucketManageAPI(CBRestConnection):
         status, content, _ = self.request(api)
         return status, content
 
+    def enable_bucket_encryption(self, bucket, secret_id):
+        """
+        POST :: /pools/default/buckets/<bucket>
+        """
+        api = f"{self.base_url}/pools/default/buckets/{bucket}"
+        params = {'encryptionAtRestSecretId': secret_id}
+        status, json_parsed, _ = self.request(api, method='POST',
+                                              params=params)
+        return status, json_parsed
+
+    def disable_bucket_encryption(self, bucket):
+        """
+        POST :: /pools/default/buckets/<bucket>
+        """
+        api = f"{self.base_url}/pools/default/buckets/{bucket}"
+        params = {'encryptionAtRestSecretId': '-1'}
+        status, json_parsed, _ = self.request(api, method='POST',
+                                              params=params)
+        return status, json_parsed
+
     def load_sample_bucket(self, bucket_name_list):
         """
         docs.couchbase.com/server/current/rest-api/rest-sample-buckets.html

--- a/cluster_nodes/settings_and_connections.py
+++ b/cluster_nodes/settings_and_connections.py
@@ -24,6 +24,28 @@ class SettingsAndConnectionsAPI(CBRestConnection):
                                               params=params)
         return status, content
 
+    def create_secret(self, params):
+        """
+        POST :: /settings/secrets
+        """
+        api = self.base_url + '/settings/secrets'
+        status, json_parsed, _ = self.request(api, method='POST',
+                                              params=params)
+        return status, json_parsed
+
+    def enable_config_encryption(self, secret_id):
+        """
+        POST :: /settings/security/encryptionAtRest
+        """
+        api = f"{self.base_url}/settings/security/encryptionAtRest"
+        params = {
+            'config.encryptionMethod': 'secret',
+            'config.encryptionSecretId': secret_id
+        }
+        status, json_parsed, _ = self.request(api, method='POST',
+                                              params=params)
+        return status, json_parsed
+
     def set_auto_compaction_settings(self, parallel_db_and_vc="false",
                                      db_fragment_threshold=None,
                                      view_fragment_threshold=None,


### PR DESCRIPTION
Adding basic API endpoints/methods for the 'encryption at rest' feature based on the documentation. These are not expected to work at the moment.